### PR TITLE
Fix missing commas

### DIFF
--- a/simple_collada_importer.py
+++ b/simple_collada_importer.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple COLLADA (.dae) Importer (Positions + Normals + Colors + UVs + Textures + Rig)",
-    "author": "ekztal"
-    "additional help": "MilesExilium"
+    "author": "ekztal",
+    "additional help": "MilesExilium",
     "version": (0, 7, 2),
     "blender": (5, 0, 0),
     "location": "File > Import > Simple COLLADA (.dae)",


### PR DESCRIPTION
As pointed out in #6 the add on could not be installed by blender due to some missing commas.
This PR simply adds these so that the plugin can be installed correctly again.